### PR TITLE
Fix bare variables in *with_* loops

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -2,7 +2,7 @@
 
 - name: Add repository to install last Apache version
   apt_repository:
-    repo="{{ apache_repository }}"
+    repo="{{apache_repository}}"
     update_cache=yes
   when: apache_repository != false
 
@@ -10,7 +10,7 @@
   apt:
     update_cache=yes
     cache_valid_time=3600
-    pkg="{{ item }}"
+    pkg="{{item}}"
     state=present
-  with_items: apache_install
+  with_items: "{{apache_install}}"
   when: apache_install != false

--- a/tasks/module.yml
+++ b/tasks/module.yml
@@ -6,7 +6,7 @@
   register: apache_cmd
   changed_when: apache_cmd.stdout.endswith(' already disabled') == false
   notify: Restart apache
-  with_items: apache_module_disable
+  with_items: "{{apache_module_disable}}"
   when: apache_module_disable != false
 
 - name: Enable apache module
@@ -15,5 +15,5 @@
   register: apache_cmd
   changed_when: apache_cmd.stdout.endswith(' already enabled') == false
   notify: Restart apache
-  with_items: apache_module_enable
+  with_items: "{{apache_module_enable}}"
   when: apache_module_enable != false

--- a/tasks/site.yml
+++ b/tasks/site.yml
@@ -6,7 +6,7 @@
   register: apache_cmd
   changed_when: apache_cmd.stdout.endswith(' already disabled') == false
   notify: Restart apache
-  with_items: apache_site_disable
+  with_items: "{{apache_site_disable}}"
   when: apache_site_disable != false
 
 - name: Enable apache site
@@ -15,5 +15,5 @@
   register: apache_cmd
   changed_when: apache_cmd.stdout.endswith(' already enabled') == false
   notify: Restart apache
-  with_items: apache_site_enable
+  with_items: "{{apache_site_enable}}"
   when: apache_site_enable != false

--- a/tasks/vhost.yml
+++ b/tasks/vhost.yml
@@ -6,7 +6,7 @@
     dest="/etc/apache2/sites-available/{{ item.server_file_name }}.conf"
     owner=root group=root mode=644
   notify: Restart apache
-  with_items: apache_vhosts
+  with_items: "{{apache_vhosts}}"
   when: apache_vhosts != false
 
 - name: Ensure apache SSL path exists
@@ -15,19 +15,19 @@
 - name: Ensure document base exists
   file: path="{{item.document_root | dirname | realpath }}" state=directory
   notify: Restart apache
-  with_items: apache_vhosts
+  with_items: "{{apache_vhosts}}"
   when: apache_vhosts != false
 
 - name: Ensure document root exists (dir)
   file: path="{{item.document_root | realpath}}" state=directory
   notify: Restart apache
-  with_items: apache_vhosts
+  with_items: "{{apache_vhosts}}"
   when: apache_vhosts != false and item.link_to is not defined
 
 - name: Ensure document root exists (link)
   file: src={{item.link_to}} dest={{item.document_root}} state=link force=true
   notify: Restart apache
-  with_items: apache_vhosts
+  with_items: "{{apache_vhosts}}"
   when: apache_vhosts != false and item.link_to is defined
 
 - name: Copy key
@@ -36,14 +36,14 @@
   changed_when: result.stdout
   notify: Restart apache
   with_subelements:
-   - apache_vhosts
+   - "{{apache_vhosts}}"
    - virtual_hosts
   when: apache_vhosts != false and item.1.has_ssl == true
 
 - name: Fix key permissions
   file: path="{{apache_ssl_path}}/{{item.1.key_file}}" mode=0600 state=file
   with_subelements:
-   - apache_vhosts
+   - "{{apache_vhosts}}"
    - virtual_hosts
   when: apache_vhosts != false and item.1.has_ssl == true
 
@@ -54,7 +54,7 @@
     mode: 0600
   notify: Restart apache
   with_subelements:
-   - apache_vhosts
+   - "{{apache_vhosts}}"
    - virtual_hosts
   when: apache_vhosts != false and item.1.has_ssl == true
 
@@ -65,6 +65,6 @@
     mode: 0600
   notify: Restart apache
   with_subelements:
-   - apache_vhosts
+   - "{{apache_vhosts}}"
    - virtual_hosts
   when: apache_vhosts != false and item.1.has_ssl == true and item.1.chain_file is defined


### PR DESCRIPTION
Bare variables in _with__ loops will be deprecated in Ansible 2.2, so enclosing them in braces to remove the current Ansible 2.1 warnings
