### PR TITLE
add Proxy with path template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.idea/
 tests/.vagrant

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -88,6 +88,24 @@ apache_vhosts:
         key_file: "test-ssl.key"
         proxy: http://localhost:3001
         proxy_reverse: http://127.0.0.1:3001
+  - server_name: test-proxypath.dev
+    server_admin: test-proxypath@example.com
+    server_file_name: test-proxypath
+    template: vhost_proxypath_ssl.conf.j2
+    document_root: /var/www/test-proxypath
+    virtual_hosts:
+      - has_ssl: false
+        port: 80
+        server_alias:
+          - test-proxypath.local
+          - test-proxypath.localnet
+        proxy: http://localhost:3001
+      - has_ssl: true
+        port: 443
+        certificate_file: "test-ssl.pem"
+        key_file: "test-ssl.key"
+        proxy: http://localhost:3001
+        proxy_reverse: http://127.0.0.1:3001
   - server_name: test-letsencrypt-ssl.dev
     server_admin: test-letsencrypt-ssl@example.com
     server_file_name: test-letsencrypt-ssl

--- a/templates/vhost_proxypath_ssl.conf.j2
+++ b/templates/vhost_proxypath_ssl.conf.j2
@@ -1,0 +1,57 @@
+{% for host in item.virtual_hosts %}
+<VirtualHost *:{{ host.port | default('80') }}>
+    ServerName {{ item.server_name }}
+{% if host.server_alias is defined %}    ServerAlias {{ host.server_alias | join(' ') }}
+{% endif %}
+{% if item.server_admin is defined %}    ServerAdmin {{ item.server_admin }}
+{% endif %}
+
+{% if host.has_ssl %}
+    SSLEngine On
+    SSLCertificateFile {{host.ssl_path | default(apache_ssl_path)}}/{{host.certificate_file}}
+    SSLCertificateKeyFile {{host.ssl_path | default(apache_ssl_path)}}/{{host.key_file}}
+{% if host.chain_file is defined %}    SSLCertificateChainFile {{host.ssl_path | default(apache_ssl_path)}}/{{ host.chain_file }}
+{% endif %}
+    
+{% endif %}
+    DocumentRoot {{ item.document_root }}
+{% if host.extra is defined %}
+
+{% for extra in host.extra %}
+    {{ extra }}
+{% endfor %}
+{% endif %}
+
+    <Directory />
+        Options FollowSymLinks
+        AllowOverride None
+    </Directory>
+
+    <Directory "{{ item.document_root }}">
+{% if host.directory_options is defined %}
+        Options {{ host.directory_options | join(' ') }}
+{% else %}
+        Options -Indexes +FollowSymLinks
+{% endif %}
+        AllowOverride All
+        Order allow,deny
+        Allow from all
+{% if host.directory_extra is defined %}{% for extra in host.directory_extra %}
+
+        {{ extra }}
+{% endfor %}{% endif %}
+    </Directory>
+    
+    # Possible values include: debug, info, notice, warn, error, crit,
+    # alert, emerg.
+    LogLevel warn
+
+    ErrorLog ${APACHE_LOG_DIR}/{{item.server_file_name}}_error.log
+    CustomLog ${APACHE_LOG_DIR}/{{item.server_file_name}}_access.log combined
+{% if host.proxy | default('') != '' %}
+
+    ProxyPass {{ host.proxy }}
+{% endif %}
+
+</VirtualHost>
+{% endfor %}


### PR DESCRIPTION
 - used with the CAT server

I initially tried to use the new **vhost_proxy_ssl.conf.j2** template but that doesn't work when the proxy includes a path like we need for the CAT server.