### PR TITLE
feature/wellknown

### DIFF
--- a/templates/vhost_proxy_ssl.conf.j2
+++ b/templates/vhost_proxy_ssl.conf.j2
@@ -33,7 +33,10 @@
 {% endif %}
 {% if host.proxy | default('') != '' %}
 
-   <Location />
+    # Exclude ./well-known for LetsEncrypt
+    ProxyPass /.well-known !
+
+    <Location />
         Order deny,allow
         Allow from all
         ProxyPass {{ host.proxy }}


### PR DESCRIPTION
Add a ProxyPass exclude to allow access to .well-known from the filesystem as used by LetsEncrypt.